### PR TITLE
Fix tests for the CouchDbService

### DIFF
--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/couchdb/CouchDbServiceTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/couchdb/CouchDbServiceTest.java
@@ -157,24 +157,6 @@ public class CouchDbServiceTest {
 
     @Test
     @SuppressFBWarnings(value = "PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS", justification = "document should not change")
-    public void bulkDeleteDocumentsTest_invalidUuid() throws IOException, DatabaseException {
-
-        long countBefore = this.couchDbService.getDocumentCount();
-
-        final UUID uuid1 = UUID.randomUUID();
-        String revision1 = insertTestDocument(uuid1);
-        final UUID uuid2 = UUID.randomUUID();
-        String revision2 = insertTestDocument(uuid2);
-
-        Assertions.assertEquals(countBefore + 2, this.couchDbService.getDocumentCount());
-        this.couchDbService.bulkDeleteDocuments(Arrays.asList(new IdAndRevision("Invalid uuid", revision1),
-                new IdAndRevision(uuid2.toString(), revision2)));
-
-        Assertions.assertEquals(countBefore + 1, this.couchDbService.getDocumentCount());
-    }
-
-    @Test
-    @SuppressFBWarnings(value = "PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS", justification = "document should not change")
     public void bulkDeleteDocumentsTest_invalidRevision() throws IOException {
 
         long countBefore = this.couchDbService.getDocumentCount();

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/couchdb/CouchDbServiceTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/couchdb/CouchDbServiceTest.java
@@ -128,13 +128,13 @@ public class CouchDbServiceTest {
     }
 
     @Test
-    public void deleteCsafDocumentFromDb_invalidUuid() throws IOException {
+    public void deleteCsafDocumentFromDb_doesNotExist() throws IOException {
 
         final UUID uuid = UUID.randomUUID();
         final String revision = insertTestDocument(uuid);
 
-        assertThrows(DatabaseException.class,
-                () -> this.couchDbService.deleteDocument("invalid user id", revision));
+        assertThrows(IdNotFoundException.class,
+                () -> this.couchDbService.deleteDocument("idDoesNotExist", revision));
     }
 
     @Test


### PR DESCRIPTION
Corrects the semantics of trying to delete a document that does not exist.

Removes a test on bulk deletion because the bulk post operation including a document with unknown ID will result in creating
this new document with that new ID (and a revision) as it does not refer to an existing document instead of "really deleting" something. This newly created document will still be deleted (field `_deleted` set to true) but this operation also triggers in-deterministic behavior of the couchDB, sometimes throwing a conflict error since a revision (`_rev`) is also passed.