### PR TITLE
fix: correct the recommended error status code

### DIFF
--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
@@ -172,7 +172,7 @@ public class AdvisoryService {
     IdAndRevision addAdvisoryForCredentials(CreateAdvisoryRequest newCsafJson, Authentication credentials) throws IOException, CsafException {
 
         if (newCsafJson.getSummary() == null || newCsafJson.getSummary().isBlank()) {
-            throw new CsafException("Summary must not be empty", SummaryInHistoryEmpty, UNAUTHORIZED);
+            throw new CsafException("Summary must not be empty", SummaryInHistoryEmpty, BAD_REQUEST);
         }
 
         UUID advisoryId = UUID.randomUUID();
@@ -315,7 +315,7 @@ public class AdvisoryService {
             if (canChangeAdvisory(oldAdvisoryNode, credentials)) {
 
                 if (changedCsafJson.getSummary() == null || changedCsafJson.getSummary().isBlank()) {
-                    throw new CsafException("Summary must not be empty", SummaryInHistoryEmpty, UNAUTHORIZED);
+                    throw new CsafException("Summary must not be empty", SummaryInHistoryEmpty, BAD_REQUEST);
                 }
 
                 AdvisoryWrapper newAdvisoryNode = AdvisoryWrapper.updateFromExisting(oldAdvisoryNode, changedCsafJson);

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
@@ -10,6 +10,7 @@ import static de.bsi.secvisogram.csaf_cms_backend.json.VersioningType.Semantic;
 import static de.bsi.secvisogram.csaf_cms_backend.model.filter.OperatorExpression.equal;
 import static java.util.Comparator.comparing;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -351,8 +352,9 @@ public class AdvisoryServiceTest {
     @Test
     public void updateAdvisoryTest_badData() {
         UUID noAdvisoryId = UUID.randomUUID();
-        assertThrows(DatabaseException.class, () -> advisoryService.updateAdvisory(noAdvisoryId.toString(),
+        Exception expectedException = assertThrows(DatabaseException.class, () -> advisoryService.updateAdvisory(noAdvisoryId.toString(),
                 "redundant", csafToRequest(advisoryJsonString)));
+        assertThat(expectedException.getMessage(), containsString("No element with such an ID"));
     }
 
     @Test
@@ -361,8 +363,9 @@ public class AdvisoryServiceTest {
 
         var idRev = advisoryService.addAdvisory(csafToRequest(csafDocumentJson("Category1", "Title1")));
         CreateAdvisoryRequest request = csafToRequest(csafDocumentJson("Category2", "Title2")).setSummary("");
-        assertThrows(CsafException.class,
+        Exception expectedException = assertThrows(CsafException.class,
                 () -> advisoryService.updateAdvisory(idRev.getId(), idRev.getRevision(), request));
+        assertThat(expectedException.getMessage(), containsString("Summary must not be empty"));
     }
 
     @Test
@@ -381,8 +384,9 @@ public class AdvisoryServiceTest {
         ((ObjectNode) readAdvisory.getCsaf().at("/document")).put("title", "UpdatedTitle");
         CreateAdvisoryRequest request = csafToRequest(readAdvisory.getCsaf().toPrettyString());
         request.setSummary("UpdateSummary");
-        assertThrows(IdNotFoundException.class,
+        Exception expectedException = assertThrows(IdNotFoundException.class,
                 () -> advisoryService.updateAdvisory("InvalidId", idRev.getRevision(), request));
+        assertThat(expectedException.getMessage(), containsString("No element with such an ID"));
     }
 
     @Test
@@ -402,8 +406,9 @@ public class AdvisoryServiceTest {
         ((ObjectNode) readAdvisory.getCsaf().at("/document")).put("title", "UpdatedTitle");
         CreateAdvisoryRequest request = csafToRequest(readAdvisory.getCsaf().toPrettyString());
         request.setSummary("UpdateSummary");
-        assertThrows(CsafException.class,
+        Exception expectedException = assertThrows(CsafException.class,
                 () -> advisoryService.updateAdvisory(idRev.getId(), idRev.getRevision(), request));
+        assertThat(expectedException.getMessage(), containsString("no permission"));
     }
 
     @Test
@@ -426,8 +431,9 @@ public class AdvisoryServiceTest {
         CreateAdvisoryRequest request = csafToRequest(readAdvisory.getCsaf().toPrettyString());
         request.setSummary("UpdateSummary");
 
-        assertThrows(CsafException.class,
+        Exception expectedException = assertThrows(CsafException.class,
                 () -> advisoryService.updateAdvisory(idRevComment.getId(), idRevComment.getRevision(), request));
+        assertThat(expectedException.getMessage(), containsString("not of type Advisory"));
     }
 
     @Test

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
@@ -562,13 +562,13 @@ public class AdvisoryServiceTest {
         Assertions.assertEquals(idRevComment.getRevision(), commentResp.getRevision());
         Assertions.assertEquals(comment.getCsafNodeId(), commentResp.getCsafNodeId());
         Assertions.assertEquals("author1", commentResp.getCreatedBy());
-        Assertions.assertEquals(null, commentResp.getAnswerToId());
+        Assertions.assertNull(commentResp.getAnswerToId());
 
     }
 
     @Test
     @WithMockUser(username = "author1", authorities = { CsafRoles.ROLE_AUTHOR})
-    public void addCommentTest_accessDenied() throws DatabaseException, IOException, CsafException {
+    public void addCommentTest_accessDenied() throws IOException, CsafException {
 
         IdAndRevision idRevAdvisory = advisoryService.addAdvisory(csafToRequest(csafJson));
         String commentText = "This is a comment";


### PR DESCRIPTION
when changing an advisory with empty revision history summary it's a bad request rather than unauthorized