### PR TITLE
Fix/revision history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ CSAF_VERSIONING=Semantic
 CSAF_SUMMARY_PUBLICATION="Initial Publication"
 CSAF_SUMMARY_APPROVE="Status changed from Review to Approved"
 CSAF_SUMMARY_DRAFT="Status changed from Approved to Draft"
-CSAF_SUMMARY_VERSION="New Version"
+CSAF_SUMMARY_NEW_VERSION="New Version"
 
 # validation server url for call from backend
 CSAF_VALIDATION_BASE_URL=http://localhost:8082/api/v1

--- a/.env.example
+++ b/.env.example
@@ -44,10 +44,7 @@ CSAF_COMPANY_LOGO_PATH=./src/test/resources/eXXcellent_solutions.png
 CSAF_VERSIONING=Semantic
 
 # revision history summary an workflow changes
-CSAF_SUMMARY_PUBLICATION="Initial Publication"
-CSAF_SUMMARY_APPROVE="Status changed from Review to Approved"
-CSAF_SUMMARY_DRAFT="Status changed from Approved to Draft"
-CSAF_SUMMARY_NEW_VERSION="New Version"
+CSAF_SUMMARY_PUBLICATION=Initial Publication
 
 # validation server url for call from backend
 CSAF_VALIDATION_BASE_URL=http://localhost:8082/api/v1

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/config/CsafSummaryConfiguration.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/config/CsafSummaryConfiguration.java
@@ -6,10 +6,6 @@ import org.springframework.context.annotation.Configuration;
 public class CsafSummaryConfiguration {
 
     private String publication;
-    private String approve;
-    private String draft;
-
-    private String newVersion;
 
     public String getPublication() {
         return publication;
@@ -17,33 +13,6 @@ public class CsafSummaryConfiguration {
 
     public CsafSummaryConfiguration setPublication(String publication) {
         this.publication = publication;
-        return this;
-    }
-
-    public String getApprove() {
-        return approve;
-    }
-
-    public CsafSummaryConfiguration setApprove(String approve) {
-        this.approve = approve;
-        return this;
-    }
-
-    public String getDraft() {
-        return draft;
-    }
-
-    public CsafSummaryConfiguration setDraft(String draft) {
-        this.draft = draft;
-        return this;
-    }
-
-    public String getNewVersion() {
-        return newVersion;
-    }
-
-    public CsafSummaryConfiguration setNewVersion(String newVersion) {
-        this.newVersion = newVersion;
         return this;
     }
 }

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/config/CsafSummaryConfiguration.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/config/CsafSummaryConfiguration.java
@@ -12,6 +12,9 @@ public class CsafSummaryConfiguration {
     }
 
     public CsafSummaryConfiguration setPublication(String publication) {
+        if (publication.isEmpty()) {
+            throw new IllegalArgumentException("The environment variable CSAF_SUMMARY_PUBLICATION must not be empty!");
+        }
         this.publication = publication;
         return this;
     }

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
@@ -462,7 +462,7 @@ public class AdvisoryWrapper {
 
     public void removeAllPrereleaseVersions() {
 
-        if (getVersioningStrategy().getVersioningType() == VersioningType.Semantic &&  isInitialPublicReleaseOrEarlier()) {
+        if (getVersioningStrategy().getVersioningType() == VersioningType.Semantic && isInitialPublicReleaseOrEarlier()) {
             ArrayNode historyNode = getOrCreateHistoryNode();
             historyNode.removeAll();
         }

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
@@ -56,8 +56,8 @@ public class AdvisoryWrapper {
     /**
      * Create a copy of the advisory and convert it to a AdvisoryVersion
      *
-     * @param advisoryToClone the stream
-     * @return the wrapper
+     * @param advisoryToClone the advisory to copy and convert
+     * @return the copied and converted AdvisoryWrapper
      * @throws IOException error in processing the input stream
      */
     public static AdvisoryWrapper createVersionFrom(AdvisoryWrapper advisoryToClone) throws IOException {
@@ -70,6 +70,19 @@ public class AdvisoryWrapper {
                 .setAdvisoryReference(advisoryToClone.getAdvisoryId());
         RemoveIdHelper.removeCommentIds(newAdvisory.getCsaf());
         return newAdvisory;
+    }
+
+    /**
+     * Create a copy of the advisory
+     *
+     * @param advisoryToClone the advisory to copy
+     * @return the copied AdvisoryWrapper
+     * @throws IOException error in processing the input stream
+     */
+    public static AdvisoryWrapper createCopy(AdvisoryWrapper advisoryToClone) throws IOException {
+        final ObjectMapper objMapper = new ObjectMapper();
+        String jsonStr = objMapper.writeValueAsString(advisoryToClone.advisoryNode);
+        return new AdvisoryWrapper(objMapper.readValue(jsonStr, ObjectNode.class));
     }
 
     private static ObjectNode createAdvisoryNodeFromRequest(CreateAdvisoryRequest csafJson) throws CsafException {

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
@@ -419,7 +419,7 @@ public class AdvisoryWrapper {
         String now = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
         entry.put("date", now);
         if (legacyVersion != null && !legacyVersion.isBlank()) {
-            entry.put("legacy_revision", legacyVersion);
+            entry.put("legacy_version", legacyVersion);
         }
         entry.put("number", this.getDocumentTrackingVersion());
         entry.put("summary", summary);
@@ -435,7 +435,7 @@ public class AdvisoryWrapper {
             String now = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
             entry.put("date", now);
             if (legacyVersion != null && !legacyVersion.isBlank()) {
-                entry.put("legacy_revision", legacyVersion);
+                entry.put("legacy_version", legacyVersion);
             }
             entry.put("number", this.getDocumentTrackingVersion());
             entry.put("summary", summary);
@@ -446,7 +446,7 @@ public class AdvisoryWrapper {
             }
             latestEntry.put("date", this.getDocumentTrackingCurrentReleaseDate());
             if (legacyVersion != null && !legacyVersion.isBlank()) {
-                latestEntry.put("legacy_revision", legacyVersion);
+                latestEntry.put("legacy_version", legacyVersion);
             }
             latestEntry.put("number", this.getDocumentTrackingVersion());
             latestEntry.put("summary", summary);

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/rest/AdvisoryController.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/rest/AdvisoryController.java
@@ -230,7 +230,7 @@ public class AdvisoryController {
 
         try {
             String newRevision = advisoryService.createNewCsafDocumentVersion(advisoryId, revision);
-            return ResponseEntity.ok().build();
+            return ResponseEntity.ok(newRevision);
         } catch (IOException idNfEx) {
             return ResponseEntity.badRequest().build();
         } catch (DatabaseException dbEx) {

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
@@ -417,6 +417,8 @@ public class AdvisoryService {
 
         if (canChangeWorkflow(existingAdvisoryNode, newWorkflowState, credentials)) {
 
+            String workflowStateChangeMsg = "Status changed from " + existingAdvisoryNode.getWorkflowStateString() + " to " + newWorkflowState;
+
             AuditTrailWrapper auditTrail = AdvisoryAuditTrailWorkflowWrapper.createNewFrom(newWorkflowState, existingAdvisoryNode.getWorkflowState())
                     .setDocVersion(existingAdvisoryNode.getDocumentTrackingVersion())
                     .setOldDocVersion(existingAdvisoryNode.getDocumentTrackingVersion())
@@ -437,14 +439,14 @@ public class AdvisoryService {
                 String nextVersion = existingAdvisoryNode.getVersioningStrategy()
                         .getNextApprovedVersion(existingAdvisoryNode.getDocumentTrackingVersion());
                 existingAdvisoryNode.setDocumentTrackingVersion(nextVersion);
-                existingAdvisoryNode.addRevisionHistoryEntry(configuration.getSummary().getApprove(), "");
+                existingAdvisoryNode.addRevisionHistoryEntry(workflowStateChangeMsg, "");
             }
 
             if (newWorkflowState == WorkflowState.Draft) {
                 String nextVersion = existingAdvisoryNode.getVersioningStrategy()
                         .getNextDraftVersion(existingAdvisoryNode.getDocumentTrackingVersion());
                 existingAdvisoryNode.setDocumentTrackingVersion(nextVersion);
-                existingAdvisoryNode.addRevisionHistoryEntry(configuration.getSummary().getDraft(), "");
+                existingAdvisoryNode.addRevisionHistoryEntry(workflowStateChangeMsg, "");
             }
 
             if (newWorkflowState == WorkflowState.Published) {
@@ -518,7 +520,7 @@ public class AdvisoryService {
             existingAdvisoryNode.setDocumentTrackingCurrentReleaseDate(DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
             existingAdvisoryNode.setDocumentTrackingVersion(existingAdvisoryNode.getVersioningStrategy()
                     .getNewDocumentVersion(existingAdvisoryNode.getDocumentTrackingVersion()));
-            existingAdvisoryNode.addEntryForNewCreatedVersion(configuration.getSummary().getNewVersion(), "");
+            existingAdvisoryNode.addEntryForNewCreatedVersion("New Version", "");
             existingAdvisoryNode.setRevision(revision);
 
             AuditTrailWrapper auditTrail = AdvisoryAuditTrailWorkflowWrapper.createNewFrom(WorkflowState.Draft, existingAdvisoryNode.getWorkflowState())

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
@@ -396,6 +396,8 @@ public class AdvisoryService {
     }
 
     /**
+     * Changes the workflow state of the advisory to the given new WorkflowState
+     *
      * @param advisoryId       the ID of the advisory to update the workflow state of
      * @param revision         the revision for concurrent control
      * @param newWorkflowState the new workflow state to set
@@ -474,6 +476,14 @@ public class AdvisoryService {
         }
     }
 
+    /**
+     * Adds a new version of the document in Draft workflow state
+     *
+     * @param advisoryId the ID of the advisory to create a new version of
+     * @param revision   the revision for concurrent control
+     * @return the revision of the updated CSAF document
+     * @throws DatabaseException if there was an error updating the document in the database
+     */
     public String createNewCsafDocumentVersion(String advisoryId, String revision)
             throws IOException, DatabaseException, CsafException {
 

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryService.java
@@ -468,7 +468,7 @@ public class AdvisoryService {
             existingAdvisoryNode.setRevision(revision);
             return this.couchDbService.updateDocument(existingAdvisoryNode.advisoryAsString());
         } else {
-            throw new CsafException("User has not the permission to view change the workflow state of the advisory",
+            throw new CsafException("User has not the permission to change the workflow state of the advisory",
                     NoPermissionForAdvisory, UNAUTHORIZED);
 
         }

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowUtil.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowUtil.java
@@ -437,6 +437,9 @@ public class AdvisoryWorkflowUtil {
         String vulnerabFirstAffectedRegEx = "/vulnerabilities/\\d+/product_status/first_affected/\\d+";
         String vulnerabKnownAffectedRegEx = "/vulnerabilities/\\d+/product_status/known_affected/\\d+";
         String vulnerabLastAffectedRegEx = "/vulnerabilities/\\d+/product_status/last_affected/\\d+";
+        String vulnerabFirstFixedRegEx = "/vulnerabilities/\\d+/product_status/first_fixed/\\d+";
+        String vulnerabFixedRegEx = "/vulnerabilities/\\d+/product_status/fixed/\\d+";
+        String vulnerabKnownNotAffectedRegEx = "/vulnerabilities/\\d+/product_status/known_not_affected/\\d+";
 
         for (JsonNode jsonNode : diffPatch) {
 
@@ -449,6 +452,14 @@ public class AdvisoryWorkflowUtil {
             if ("add".equals(operation) || "remove".equals(operation)) {
                 if (path.matches(vulnerabRegEx) || path.matches(vulnerabFirstAffectedRegEx)
                     || path.matches(vulnerabKnownAffectedRegEx) || path.matches(vulnerabLastAffectedRegEx)) {
+                    result = PatchType.MAJOR;
+                    break;
+                }
+                result = PatchType.MINOR;
+            }
+            if ("remove".equals(operation)) {
+                if (path.matches(vulnerabFirstFixedRegEx) || path.matches(vulnerabFixedRegEx)
+                    || path.matches(vulnerabKnownNotAffectedRegEx)) {
                     result = PatchType.MAJOR;
                     break;
                 }

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClient.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClient.java
@@ -27,9 +27,11 @@ public class ValidatorServiceClient {
     private static final Logger LOG = LoggerFactory.getLogger(ValidatorServiceClient.class);
 
     private static final String VALIDATE_ENDPOINT = "/validate";
-    private static final ValidationRequestTest csafTest = new ValidationRequestTest("test", "csaf_2_0");
-    private static final ValidationRequestTest optionalTest = new ValidationRequestTest("preset", "optional");
-    private static final ValidationRequestTest[] allValidationTests = {csafTest};
+    private static final ValidationRequestTest csafSchemaTest = new ValidationRequestTest("test", "csaf_2_0");
+    private static final ValidationRequestTest mandatoryTest = new ValidationRequestTest("preset", "mandatory");
+//    private static final ValidationRequestTest optionalTest = new ValidationRequestTest("preset", "optional");
+//    private static final ValidationRequestTest informativeTest = new ValidationRequestTest("preset", "informative");
+    private static final ValidationRequestTest[] allValidationTests = {csafSchemaTest, mandatoryTest};
 
     public static boolean isAdvisoryValid(String baseUrl, AdvisoryWrapper advisory) throws CsafException {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ csaf.document.versioning=${CSAF_VERSIONING:}
 csaf.summary.publication=${CSAF_SUMMARY_PUBLICATION:}
 csaf.summary.approve=${CSAF_SUMMARY_APPROVE:}
 csaf.summary.draft=${CSAF_SUMMARY_DRAFT:}
-csaf.summary.version=${CSAF_SUMMARY_VERSION:}
+csaf.summary.newVersion=${CSAF_SUMMARY_NEW_VERSION:}
 #validation
 csaf.validation.baseurl=${CSAF_VALIDATION_BASE_URL:}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,10 +22,8 @@ csaf.document.templates.companyLogoPath=${CSAF_COMPANY_LOGO_PATH:}
 csaf.document.versioning=${CSAF_VERSIONING:}
 
 # revision history
-csaf.summary.publication=${CSAF_SUMMARY_PUBLICATION:}
-csaf.summary.approve=${CSAF_SUMMARY_APPROVE:}
-csaf.summary.draft=${CSAF_SUMMARY_DRAFT:}
-csaf.summary.newVersion=${CSAF_SUMMARY_NEW_VERSION:}
+csaf.summary.publication=${CSAF_SUMMARY_PUBLICATION:Initial Publication}
+
 #validation
 csaf.validation.baseurl=${CSAF_VALIDATION_BASE_URL:}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ csaf.document.templates.file=${CSAF_TEMPLATES_FILE:}
 csaf.document.templates.companyLogoPath=${CSAF_COMPANY_LOGO_PATH:}
 
 # versioning
-csaf.document.versioning=${CSAF_VERSIONING:}
+csaf.document.versioning=${CSAF_VERSIONING:Semantic}
 
 # revision history
 csaf.summary.publication=${CSAF_SUMMARY_PUBLICATION:Initial Publication}

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/fixture/CsafDocumentJsonCreator.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/fixture/CsafDocumentJsonCreator.java
@@ -61,28 +61,6 @@ public class CsafDocumentJsonCreator {
                 }""".formatted(documentTitle, releaseDate);
     }
 
-    public static String csafJsonTitleReleaseDateVersion(String documentTitle, String releaseDate, String version) {
-
-        return """
-                { "document": {
-                      "category": "Category1",
-                      "title": "%s",
-                      "tracking": {
-                          "current_release_date": "%s",
-                          "version":"%s",
-                          "status": "draft",
-                          "revision_history":[
-                            { "summary": null,
-                              "legacy_revision": null,
-                              "number": "%s",
-                              "date": "%s"
-                            }
-                          ]
-                      }
-                   }
-                }""".formatted(documentTitle, releaseDate, version, version, releaseDate);
-
-    }
     public static String csafJsonCategoryTitle(String documentCategory, String documentTitle) {
 
         return """
@@ -94,7 +72,7 @@ public class CsafDocumentJsonCreator {
     }
 
 
-    public static String csafJsonTrackingGenratorVersion(String version) {
+    public static String csafJsonTrackingGeneratorVersion(String version) {
 
         return """
                 {

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/fixture/CsafDocumentJsonCreator.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/fixture/CsafDocumentJsonCreator.java
@@ -25,6 +25,50 @@ public class CsafDocumentJsonCreator {
         return request;
     }
 
+    public static String csafMinimalValidDoc() {
+        return """
+                {
+                    "document": {
+                        "category": "CSAF Base",
+                        "csaf_version": "2.0",
+                        "title": "Minimal Valid Doc",
+                        "lang": "en",
+                        "distribution": {
+                            "tlp": {
+                                "label": "GREEN"
+                            }
+                        },
+                        "publisher": {
+                            "category": "other",
+                            "name": "Secvisogram Automated Tester",
+                            "namespace": "https://github.com/secvisogram/secvisogram"
+                        },
+                        "references": [
+                            {
+                                "category": "self",
+                                "summary": "A non-canonical URL",
+                                "url": "https://example.com/security/data/csaf/2021/my-thing-_10.json"
+                            }
+                        ],
+                        "tracking": {
+                            "current_release_date": "2022-09-08T12:33:45.678Z",
+                            "id": "My-Thing-.10",
+                            "initial_release_date": "2022-09-08T12:33:45.678Z",
+                            "revision_history": [
+                                {
+                                    "number": "0.0.1",
+                                    "date": "2022-09-08T12:33:45.678Z",
+                                    "summary": "initial draft"
+                                }
+                            ],
+                            "status": "draft",
+                            "version": "0.0.1"
+                        }
+                    }
+                }
+                """;
+    }
+
     public static String csafJsonCategoryTitleId(String category, String documentTitle, String documentTrackingId) {
 
         return """

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapperTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapperTest.java
@@ -189,21 +189,21 @@ public class AdvisoryWrapperTest {
         String dateNowMinutes =  DateTimeFormatter.ISO_INSTANT.format(Instant.now()).substring(0, 16);
         assertThat(getRevisionAt(advisory, 0, "number"), equalTo("0.1.1"));
         assertThat(getRevisionAt(advisory, 0, "summary"), equalTo("Summary1"));
-        assertThat(getRevisionAt(advisory, 0, "legacy_revision"), equalTo("LegacyVersion1"));
+        assertThat(getRevisionAt(advisory, 0, "legacy_version"), equalTo("LegacyVersion1"));
         assertThat(getRevisionAt(advisory, 0, "date"), startsWith(dateNowMinutes));
 
         advisory.setDocumentTrackingVersion("0.1.2");
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary2", "LegacyVersion2"));
         assertThat(getRevisionAt(advisory, 1, "number"), equalTo("0.1.2"));
         assertThat(getRevisionAt(advisory, 1, "summary"), equalTo("Summary2"));
-        assertThat(getRevisionAt(advisory, 1, "legacy_revision"), equalTo("LegacyVersion2"));
+        assertThat(getRevisionAt(advisory, 1, "legacy_version"), equalTo("LegacyVersion2"));
         assertThat(getRevisionAt(advisory, 1, "date"), startsWith(dateNowMinutes));
 
         advisory.setDocumentTrackingVersion("1.0.0");
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary3", "LegacyVersion3"));
         assertThat(getRevisionAt(advisory, 2, "number"), equalTo("1.0.0"));
         assertThat(getRevisionAt(advisory, 2, "summary"), equalTo("Summary3"));
-        assertThat(getRevisionAt(advisory, 2, "legacy_revision"), equalTo("LegacyVersion3"));
+        assertThat(getRevisionAt(advisory, 2, "legacy_version"), equalTo("LegacyVersion3"));
         assertThat(getRevisionAt(advisory, 2, "date"), startsWith(dateNowMinutes));
 
         advisory.setLastVersion("1.0.0");
@@ -211,7 +211,7 @@ public class AdvisoryWrapperTest {
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary4", "LegacyVersion4"));
         assertThat(getRevisionAt(advisory, 3, "number"), equalTo("1.0.1"));
         assertThat(getRevisionAt(advisory, 3, "summary"), equalTo("Summary4"));
-        assertThat(getRevisionAt(advisory, 3, "legacy_revision"), equalTo("LegacyVersion4"));
+        assertThat(getRevisionAt(advisory, 3, "legacy_version"), equalTo("LegacyVersion4"));
         assertThat(getRevisionAt(advisory, 3, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
 
 
@@ -219,14 +219,14 @@ public class AdvisoryWrapperTest {
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary5", "LegacyVersion5"));
         assertThat(getRevisionAt(advisory, 3, "number"), equalTo("1.0.2"));
         assertThat(getRevisionAt(advisory, 3, "summary"), equalTo("Summary5"));
-        assertThat(getRevisionAt(advisory, 3, "legacy_revision"), equalTo("LegacyVersion5"));
+        assertThat(getRevisionAt(advisory, 3, "legacy_version"), equalTo("LegacyVersion5"));
         assertThat(getRevisionAt(advisory, 3, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
 
         advisory.setDocumentTrackingVersion("2.0.0");
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary6", "LegacyVersion6"));
         assertThat(getRevisionAt(advisory, 3, "number"), equalTo("2.0.0"));
         assertThat(getRevisionAt(advisory, 3, "summary"), equalTo("Summary6"));
-        assertThat(getRevisionAt(advisory, 3, "legacy_revision"), equalTo("LegacyVersion6"));
+        assertThat(getRevisionAt(advisory, 3, "legacy_version"), equalTo("LegacyVersion6"));
         assertThat(getRevisionAt(advisory, 3, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
         assertThat(advisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(4));
     }
@@ -243,21 +243,21 @@ public class AdvisoryWrapperTest {
 
         assertThat(getRevisionAt(advisory, 0, "number"), equalTo("0"));
         assertThat(getRevisionAt(advisory, 0, "summary"), equalTo("Summary1"));
-        assertThat(getRevisionAt(advisory, 0, "legacy_revision"), equalTo("LegacyVersion1"));
+        assertThat(getRevisionAt(advisory, 0, "legacy_version"), equalTo("LegacyVersion1"));
         assertThat(getRevisionAt(advisory, 0, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
 
         advisory.setDocumentTrackingVersion("1");
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary2", "LegacyVersion2"));
         assertThat(getRevisionAt(advisory, 0, "number"), equalTo("1"));
         assertThat(getRevisionAt(advisory, 0, "summary"), equalTo("Summary2"));
-        assertThat(getRevisionAt(advisory, 0, "legacy_revision"), equalTo("LegacyVersion2"));
+        assertThat(getRevisionAt(advisory, 0, "legacy_version"), equalTo("LegacyVersion2"));
         assertThat(getRevisionAt(advisory, 0, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
 
         advisory.setDocumentTrackingVersion("1");
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary3", "LegacyVersion3"));
         assertThat(getRevisionAt(advisory, 0, "number"), equalTo("1"));
         assertThat(getRevisionAt(advisory, 0, "summary"), equalTo("Summary3"));
-        assertThat(getRevisionAt(advisory, 0, "legacy_revision"), equalTo("LegacyVersion3"));
+        assertThat(getRevisionAt(advisory, 0, "legacy_version"), equalTo("LegacyVersion3"));
         assertThat(getRevisionAt(advisory, 0, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
 
         advisory.setLastVersion("1");
@@ -265,21 +265,21 @@ public class AdvisoryWrapperTest {
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary4", "LegacyVersion4"));
         assertThat(getRevisionAt(advisory, 1, "number"), equalTo("2"));
         assertThat(getRevisionAt(advisory, 1, "summary"), equalTo("Summary4"));
-        assertThat(getRevisionAt(advisory, 1, "legacy_revision"), equalTo("LegacyVersion4"));
+        assertThat(getRevisionAt(advisory, 1, "legacy_version"), equalTo("LegacyVersion4"));
         assertThat(getRevisionAt(advisory, 1, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
 
         advisory.setDocumentTrackingVersion("2");
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary5", "LegacyVersion5"));
         assertThat(getRevisionAt(advisory, 1, "number"), equalTo("2"));
         assertThat(getRevisionAt(advisory, 1, "summary"), equalTo("Summary5"));
-        assertThat(getRevisionAt(advisory, 1, "legacy_revision"), equalTo("LegacyVersion5"));
+        assertThat(getRevisionAt(advisory, 1, "legacy_version"), equalTo("LegacyVersion5"));
         assertThat(getRevisionAt(advisory, 1, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
 
         advisory.setDocumentTrackingVersion("2");
         advisory.addRevisionHistoryEntry(new CreateAdvisoryRequest("Summary6", "LegacyVersion6"));
         assertThat(getRevisionAt(advisory, 1, "number"), equalTo("2"));
         assertThat(getRevisionAt(advisory, 1, "summary"), equalTo("Summary6"));
-        assertThat(getRevisionAt(advisory, 1, "legacy_revision"), equalTo("LegacyVersion6"));
+        assertThat(getRevisionAt(advisory, 1, "legacy_version"), equalTo("LegacyVersion6"));
         assertThat(getRevisionAt(advisory, 1, "date"), equalTo(advisory.getDocumentTrackingCurrentReleaseDate()));
         assertThat(advisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
     }

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/json/IntegerVersioningTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/json/IntegerVersioningTest.java
@@ -21,7 +21,7 @@ public class IntegerVersioningTest {
     }
 
     @Test
-    public void getNextVersion() {
+    public void getNextVersionTest() {
 
         assertThat(IntegerVersioning.getDefault().getNextVersion(PatchType.PATCH, "0", "0"), is("0"));
         assertThat(IntegerVersioning.getDefault().getNextVersion(PatchType.PATCH, "1", "0"), is("1"));
@@ -35,7 +35,7 @@ public class IntegerVersioningTest {
     }
 
     @Test
-    public void getRemoveVersionTest() {
+    public void removeVersionSuffixTest() {
         assertThat(IntegerVersioning.getDefault().removeVersionSuffix("1"), is("1"));
         assertThat(IntegerVersioning.getDefault().removeVersionSuffix("2"), is("2"));
     }

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/json/SemanticVersioningTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/json/SemanticVersioningTest.java
@@ -82,9 +82,16 @@ public class SemanticVersioningTest {
     }
 
     @Test
-    public void getRemoveVersionTest() {
+    public void removeVersionSuffixTest() {
         assertThat(SemanticVersioning.getDefault().removeVersionSuffix("0.0.1"), is("0.0.1"));
         assertThat(SemanticVersioning.getDefault().removeVersionSuffix("0.1.0-1.0"), is("0.1.0"));
         assertThat(SemanticVersioning.getDefault().removeVersionSuffix("2.0.1-2.11"), is("2.0.1"));
     }
+
+    @Test
+    public void getNewDocumentVersionTest() {
+        assertThat(SemanticVersioning.getDefault().getNewDocumentVersion("1.0.0"), is("1.0.1-1.0"));
+        assertThat(SemanticVersioning.getDefault().getNewDocumentVersion("2.0.0"), is("2.0.1-1.0"));
+    }
+
 }

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisorySearchUtilTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisorySearchUtilTest.java
@@ -51,8 +51,8 @@ public class AdvisorySearchUtilTest {
     @WithMockUser(username = "editor", authorities = {CsafRoles.ROLE_REGISTERED, CsafRoles.ROLE_AUTHOR})
     public void getAdvisoryInformationsTest_documentTrackingGeneratorVersion() throws IOException, CsafException {
 
-        IdAndRevision idRev1 = this.advisoryService.addAdvisory(csafToRequest(csafJsonTrackingGenratorVersion("1.2.3")));
-        this.advisoryService.addAdvisory(csafToRequest(csafJsonTrackingGenratorVersion("3.4.5")));
+        IdAndRevision idRev1 = this.advisoryService.addAdvisory(csafToRequest(csafJsonTrackingGeneratorVersion("1.2.3")));
+        this.advisoryService.addAdvisory(csafToRequest(csafJsonTrackingGeneratorVersion("3.4.5")));
         List<AdvisoryInformationResponse> infos =
                 this.advisoryService.getAdvisoryInformations(createExprTrackingGeneratorVersion("1.2.3"));
         List<String> ids = infos.stream().map(AdvisoryInformationResponse::getAdvisoryId).toList();

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
@@ -449,6 +449,8 @@ public class AdvisoryServiceTest {
 
     @Test
     @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR, CsafRoles.ROLE_REVIEWER})
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "Bug in SpotBugs: https://github.com/spotbugs/spotbugs/issues/1338")
     public void changeAdvisoryWorkflowStateTest_RfPublication() throws IOException, DatabaseException, CsafException {
 
         try (final MockedStatic<ValidatorServiceClient> validatorMock = Mockito.mockStatic(ValidatorServiceClient.class)) {
@@ -467,6 +469,8 @@ public class AdvisoryServiceTest {
 
     @Test
     @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR, CsafRoles.ROLE_REVIEWER})
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "Bug in SpotBugs: https://github.com/spotbugs/spotbugs/issues/1338")
     public void changeAdvisoryWorkflowStateTest_RfPublication_invalidDoc() throws IOException, DatabaseException, CsafException {
 
         try (final MockedStatic<ValidatorServiceClient> validatorMock = Mockito.mockStatic(ValidatorServiceClient.class)) {
@@ -505,8 +509,6 @@ public class AdvisoryServiceTest {
 
     @Test
     @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR, CsafRoles.ROLE_REVIEWER, CsafRoles.ROLE_PUBLISHER})
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-            justification = "Bug in SpotBugs: https://github.com/spotbugs/spotbugs/issues/1338")
     public void createNewCsafDocumentVersionTest_accessDenied() throws IOException, CsafException {
 
         IdAndRevision idRev = advisoryService.addAdvisory(csafToRequest(csafJson));
@@ -516,8 +518,6 @@ public class AdvisoryServiceTest {
 
     @Test
     @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR, CsafRoles.ROLE_REVIEWER, CsafRoles.ROLE_PUBLISHER})
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-            justification = "Bug in SpotBugs: https://github.com/spotbugs/spotbugs/issues/1338")
     public void createNewCsafDocumentVersionTest_invalidId() throws IOException, CsafException {
 
         IdAndRevision idRev = advisoryService.addAdvisory(csafToRequest(csafJson));

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryServiceTest.java
@@ -448,6 +448,41 @@ public class AdvisoryServiceTest {
     }
 
     @Test
+    @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR, CsafRoles.ROLE_REVIEWER})
+    public void changeAdvisoryWorkflowStateTest_RfPublication() throws IOException, DatabaseException, CsafException {
+
+        try (final MockedStatic<ValidatorServiceClient> validatorMock = Mockito.mockStatic(ValidatorServiceClient.class)) {
+
+            validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.TRUE);
+
+            IdAndRevision idRev = advisoryService.addAdvisory(csafToRequest(csafJson));
+            String revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), idRev.getRevision(), WorkflowState.Review, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
+            advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);
+
+            assertEquals(WorkflowState.RfPublication, advisoryService.getAdvisory(idRev.getId()).getWorkflowState());
+
+        }
+    }
+
+    @Test
+    @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR, CsafRoles.ROLE_REVIEWER})
+    public void changeAdvisoryWorkflowStateTest_RfPublication_invalidDoc() throws IOException, DatabaseException, CsafException {
+
+        try (final MockedStatic<ValidatorServiceClient> validatorMock = Mockito.mockStatic(ValidatorServiceClient.class)) {
+
+            validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.FALSE);
+
+            IdAndRevision idRev = advisoryService.addAdvisory(csafToRequest(csafJson));
+            String rev1 = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), idRev.getRevision(), WorkflowState.Review, null, null);
+            String rev2 = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), rev1, WorkflowState.Approved, null, null);
+
+            assertThrows(CsafException.class, () -> advisoryService.changeAdvisoryWorkflowState(idRev.getId(), rev2, WorkflowState.RfPublication, null, null));
+
+        }
+    }
+
+    @Test
     @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR, CsafRoles.ROLE_REVIEWER, CsafRoles.ROLE_PUBLISHER})
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "Bug in SpotBugs: https://github.com/spotbugs/spotbugs/issues/1338")

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
@@ -131,9 +131,10 @@ public class AdvisoryWorkflowTest {
             String revision = advisoryService.updateAdvisory(idRev.getId(), idRev.getRevision(), request);
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
-            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);
 
             validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.TRUE);
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);
 
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
             advisoryService.createNewCsafDocumentVersion(idRev.getId(), revision);
@@ -214,6 +215,8 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("0.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/2/number").asText(), equalTo("1.0.0-1.0"));
 
+            validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.TRUE);
+
             // workflow to RfPublication
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
@@ -221,7 +224,6 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(3));
 
             // workflow to Published
-            validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.TRUE);
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.0"));

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
@@ -5,10 +5,10 @@ import static de.bsi.secvisogram.csaf_cms_backend.fixture.CsafDocumentJsonCreato
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.bsi.secvisogram.csaf_cms_backend.CouchDBExtension;
 import de.bsi.secvisogram.csaf_cms_backend.config.CsafRoles;
@@ -23,6 +23,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -51,7 +52,6 @@ import org.springframework.test.context.ContextConfiguration;
 @DirtiesContext
 @ContextConfiguration
 @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE", justification = "False positives on multiline format strings")
-
 public class AdvisoryWorkflowTest {
 
     private static final String EMPTY_PASSWD = "";
@@ -202,9 +202,7 @@ public class AdvisoryWorkflowTest {
             var readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("0.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("0.0.1"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             //update advisory
             CreateAdvisoryRequest request = csafToRequest(readAdvisory.getCsaf().toPrettyString());
@@ -215,18 +213,14 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("0.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("0.0.2"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow to review
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("0.0.2"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow to approved
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
@@ -235,9 +229,7 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(3));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("0.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/2/number").asText(), equalTo("1.0.0-1.0"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.TRUE);
 
@@ -246,9 +238,7 @@ public class AdvisoryWorkflowTest {
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.0-1.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(3));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow to Published
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
@@ -256,9 +246,7 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(1));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow new Version
             advisoryService.createNewCsafDocumentVersion(idRev.getId(), revision);
@@ -267,9 +255,7 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1-1.0"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             //update advisory 2
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
@@ -281,18 +267,14 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1-1.1"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow to review 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.1-1.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow to approved 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
@@ -301,18 +283,14 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1-2.0"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow to RfPublication 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.1-2.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow to Published 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
@@ -321,9 +299,7 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
             // workflow new Version
             advisoryService.createNewCsafDocumentVersion(idRev.getId(), revision);
@@ -333,11 +309,156 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/2/number").asText(), equalTo("1.0.2-1.0"));
-            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
-                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
-            );
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
 
         }
+    }
+
+    @Test
+    @WithMockUser(username = "manager", authorities = {CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR,
+            CsafRoles.ROLE_MANAGER, CsafRoles.ROLE_REVIEWER, CsafRoles.ROLE_PUBLISHER})
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "Bug in SpotBugs: https://github.com/spotbugs/spotbugs/issues/1338")
+    public void workflowTest_revisionHistory_allStateChanges() throws IOException, DatabaseException, CsafException {
+
+        final ObjectMapper jacksonMapper = new ObjectMapper();
+
+        try (final MockedStatic<ValidatorServiceClient> validatorMock = Mockito.mockStatic(ValidatorServiceClient.class)) {
+            validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.TRUE);
+
+            final String csafJson = csafMinimalValidDoc();
+            IdAndRevision idRev = advisoryService.addAdvisory(csafToRequest(csafJson));
+
+            AdvisoryResponse currentAdvisory = advisoryService.getAdvisory(idRev.getId());
+            ((ObjectNode) currentAdvisory.getCsaf().at("/document")).put("title", "Pre-release Title");
+            CreateAdvisoryRequest request = csafToRequest(currentAdvisory.getCsaf().toPrettyString());
+            request.setSummary("updated title in pre-release draft");
+            String revision = advisoryService.updateAdvisory(idRev.getId(), idRev.getRevision(), request);
+
+            AdvisoryResponse readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("0.0.1", "0.0.2"),
+                    "in pre-release stage change of title should trigger a patch version raise");
+
+            currentAdvisory = advisoryService.getAdvisory(idRev.getId());
+            ObjectNode emptyProductTree = jacksonMapper.createObjectNode();
+            ((ObjectNode) currentAdvisory.getCsaf()).set("product_tree", emptyProductTree);
+            request = csafToRequest(currentAdvisory.getCsaf().toPrettyString());
+            request.setSummary("added empty product_tree");
+            revision = advisoryService.updateAdvisory(idRev.getId(), revision, request);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("0.0.1", "0.0.2", "0.1.0"),
+                    "in pre-release stage change of product_tree should trigger a minor version raise");
+
+            // going through multiple workflow state changes should add revision history items for
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Draft, null, null);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("0.0.1", "0.0.2", "0.1.0", "0.1.0-1.0"),
+                    "going back from Review to Draft should add pre-release counter");
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("0.0.1", "0.0.2", "0.1.0", "0.1.0-1.0", "1.0.0-1.0"),
+                    "going to Approved should raise major version");
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Draft, null, null);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("0.0.1", "0.0.2", "0.1.0", "0.1.0-1.0", "1.0.0-1.0", "1.0.0-1.1"),
+                    "going back from Approved to Draft should increment second part of pre-release counter");
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("0.0.1", "0.0.2", "0.1.0", "0.1.0-1.0", "1.0.0-1.0", "1.0.0-1.1", "1.0.0-2.0"),
+                    "going to Approved should increment pre-release counter");
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);  // sollte man hier wieder zurück zu draft gehen können?
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertEquals(7, readAdvisory.getCsaf().at("/document/tracking/revision_history").size(),
+                    "going to RfPublication should not add revision history item");
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("1.0.0"),
+                    "Publishing the advisory for the first time should delete all prerelease version entries and set version 1.0.0");
+
+            revision = advisoryService.createNewCsafDocumentVersion(idRev.getId(), revision);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("1.0.0", "1.0.1-1.0"),
+                    "creating new version should raise patch version and add pre-release counter");
+
+            currentAdvisory = advisoryService.getAdvisory(idRev.getId());
+            ((ObjectNode) currentAdvisory.getCsaf().at("/document")).put("title", "Updated Title After Release");
+            request = csafToRequest(currentAdvisory.getCsaf().toPrettyString());
+            request.setSummary("updated title after release");
+            revision = advisoryService.updateAdvisory(idRev.getId(), revision, request);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("1.0.0", "1.1.0-1.1"),
+                    "after release change of title should trigger minor version raise, including pre-release part");
+
+            currentAdvisory = advisoryService.getAdvisory(idRev.getId());
+            ((ObjectNode) currentAdvisory.getCsaf()).remove("product_tree");
+            request = csafToRequest(currentAdvisory.getCsaf().toPrettyString());
+            request.setSummary("removed product_tree");
+            revision = advisoryService.updateAdvisory(idRev.getId(), revision, request);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("1.0.0", "2.0.0-1.2"),
+                    "after release stage change of product_tree should trigger a major version raise");
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Draft, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Draft, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("1.0.0", "2.0.0-5.0"),
+                    "after release stage workflow changes should only update the first part of the pre-release " +
+                    "part of the existing revision history item and there were 4 relevant updates");
+            assertRevisionHistorySummariesNonEmpty(readAdvisory);
+
+            revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
+
+            readAdvisory = advisoryService.getAdvisory(idRev.getId());
+            assertRevisionHistoryVersionsMatch(readAdvisory, List.of("1.0.0", "2.0.0"),
+                    "publishing the advisory should remove the pre-release part");
+
+        }
+    }
+
+    private void assertRevisionHistoryVersionsMatch(AdvisoryResponse advisory, List<String> expectedVersions, String message) {
+        List<String> revisionHistoryVersions = getRevisionHistoryVersions(advisory);
+        assertEquals(expectedVersions, revisionHistoryVersions, message);
+    }
+
+    private List<String> getRevisionHistoryVersions(AdvisoryResponse advisory) {
+        List<String> versionNumbers = new ArrayList<>();
+        advisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                revHistItem -> versionNumbers.add(revHistItem.at("/number").asText())
+            );
+        return versionNumbers;
+    }
+
+    private void assertRevisionHistorySummariesNonEmpty(AdvisoryResponse advisory) {
+        advisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText(),
+                        "summary must not be empty!")
+        );
     }
 
 

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
@@ -116,6 +116,17 @@ public class AdvisoryWorkflowTest {
     }
 
     @Test
+    @WithMockUser(username = "editor1", authorities = { CsafRoles.ROLE_EDITOR})
+    public void workflowTest_unallowedStateChange() throws IOException, CsafException {
+
+        final String advisoryUser = "John";
+        final String csafJson = csafJsonCategoryTitle("Category1", "Title1");
+        IdAndRevision idRev = advisoryService.addAdvisoryForCredentials(csafToRequest(csafJson), createAuthentication(advisoryUser, AUTHOR.getRoleName()));
+
+        assertThrows(CsafException.class, () -> advisoryService.changeAdvisoryWorkflowState(idRev.getId(), idRev.getRevision(), WorkflowState.Published, null, null));
+    }
+
+    @Test
     @WithMockUser(username = "manager", authorities = {CsafRoles.ROLE_REGISTERED, CsafRoles.ROLE_AUTHOR, CsafRoles.ROLE_EDITOR,
             CsafRoles.ROLE_MANAGER, CsafRoles.ROLE_REVIEWER, CsafRoles.ROLE_PUBLISHER})
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowTest.java
@@ -5,6 +5,7 @@ import static de.bsi.secvisogram.csaf_cms_backend.fixture.CsafDocumentJsonCreato
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -201,6 +202,9 @@ public class AdvisoryWorkflowTest {
             var readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("0.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("0.0.1"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             //update advisory
             CreateAdvisoryRequest request = csafToRequest(readAdvisory.getCsaf().toPrettyString());
@@ -211,12 +215,18 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("0.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("0.0.2"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow to review
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("0.0.2"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow to approved
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
@@ -225,6 +235,9 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(3));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("0.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/2/number").asText(), equalTo("1.0.0-1.0"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             validatorMock.when(() -> ValidatorServiceClient.isAdvisoryValid(any(), any())).thenReturn(Boolean.TRUE);
 
@@ -233,6 +246,9 @@ public class AdvisoryWorkflowTest {
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.0-1.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(3));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow to Published
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
@@ -240,6 +256,9 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(1));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow new Version
             advisoryService.createNewCsafDocumentVersion(idRev.getId(), revision);
@@ -248,6 +267,9 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1-1.0"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             //update advisory 2
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
@@ -259,12 +281,18 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1-1.1"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow to review 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Review, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.1-1.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow to approved 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Approved, null, null);
@@ -273,12 +301,18 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1-2.0"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow to RfPublication 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.RfPublication, null, null);
             readAdvisory = advisoryService.getAdvisory(idRev.getId());
             assertThat(readAdvisory.getCsaf().at("/document/tracking/version").asText(), equalTo("1.0.1-2.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow to Published 2
             revision = advisoryService.changeAdvisoryWorkflowState(idRev.getId(), revision, WorkflowState.Published, null, null);
@@ -287,6 +321,9 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history").size(), equalTo(2));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
             // workflow new Version
             advisoryService.createNewCsafDocumentVersion(idRev.getId(), revision);
@@ -296,6 +333,9 @@ public class AdvisoryWorkflowTest {
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/0/number").asText(), equalTo("1.0.0"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/1/number").asText(), equalTo("1.0.1"));
             assertThat(readAdvisory.getCsaf().at("/document/tracking/revision_history/2/number").asText(), equalTo("1.0.2-1.0"));
+            readAdvisory.getCsaf().at("/document/tracking/revision_history").forEach(
+                    revHistoryNode -> assertNotEquals("", revHistoryNode.get("summary").asText())
+            );
 
         }
     }

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowUtilTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/service/AdvisoryWorkflowUtilTest.java
@@ -500,16 +500,19 @@ public class AdvisoryWorkflowUtilTest {
     }
 
     @Test
-    public void getChangeTypeTest_addVulnerabilityProductStatusFirstAffected1() throws IOException, CsafException {
+    public void getChangeTypeTest_addVulnerabilityProductStatusFirstAffected() throws IOException, CsafException {
 
         String oldVul = """
-                 [
+                 [ { "product_status": {
+                      "first_affected": ["CSAFPID-0001"]
+                     }
+                   }
                   ]
                 """;
 
         String newVul = """
                  [ { "product_status": {
-                      "first_affected": ["CSAFPID-0001"]
+                      "first_affected": ["CSAFPID-0001", "CSAFPID-0002"]
                      }
                    }
                   ]
@@ -525,7 +528,7 @@ public class AdvisoryWorkflowUtilTest {
     }
 
     @Test
-    public void getChangeTypeTest_addVulnerabilityProductStatusFirstAffected() throws IOException, CsafException {
+    public void getChangeTypeTest_addVulnerabilityProductStatusKnownAffected() throws IOException, CsafException {
 
         String oldVul = """
                  [ { "product_status": {
@@ -538,6 +541,202 @@ public class AdvisoryWorkflowUtilTest {
         String newVul = """
                  [ { "product_status": {
                       "known_affected": ["CSAFPID-0001", "CSAFPID-0002"]
+                     }
+                   }
+                  ]
+                """;
+
+
+        String oldCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(oldVul);
+        AdvisoryWrapper oldAdvisory = AdvisoryWrapper.createNewFromCsaf(csafToRequest(oldCsafJson), "user1", Semantic.name());
+        String newCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(newVul);
+        AdvisoryWrapper newAdvisory = AdvisoryWrapper.updateFromExisting(oldAdvisory, csafToRequest(newCsafJson));
+
+        assertThat(AdvisoryWorkflowUtil.getChangeType(oldAdvisory, newAdvisory, 4), is(PatchType.MAJOR));
+    }
+
+    @Test
+    public void getChangeTypeTest_addVulnerabilityProductStatusLastAffected() throws IOException, CsafException {
+
+        String oldVul = """
+                 [ { "product_status": {
+                      "last_affected": ["CSAFPID-0001"]
+                     }
+                   }
+                  ]
+                """;
+
+        String newVul = """
+                 [ { "product_status": {
+                      "last_affected": ["CSAFPID-0001", "CSAFPID-0002"]
+                     }
+                   }
+                  ]
+                """;
+
+
+        String oldCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(oldVul);
+        AdvisoryWrapper oldAdvisory = AdvisoryWrapper.createNewFromCsaf(csafToRequest(oldCsafJson), "user1", Semantic.name());
+        String newCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(newVul);
+        AdvisoryWrapper newAdvisory = AdvisoryWrapper.updateFromExisting(oldAdvisory, csafToRequest(newCsafJson));
+
+        assertThat(AdvisoryWorkflowUtil.getChangeType(oldAdvisory, newAdvisory, 4), is(PatchType.MAJOR));
+    }
+
+    @Test
+    public void getChangeTypeTest_removeVulnerabilityProductStatusFirstAffected() throws IOException, CsafException {
+
+        String oldVul = """
+                 [ { "product_status": {
+                      "first_affected": ["CSAFPID-0001"]
+                     }
+                   }
+                  ]
+                """;
+
+        String newVul = """
+                 [ { "product_status": {
+                      "first_affected": []
+                     }
+                   }
+                  ]
+                """;
+
+
+        String oldCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(oldVul);
+        AdvisoryWrapper oldAdvisory = AdvisoryWrapper.createNewFromCsaf(csafToRequest(oldCsafJson), "user1", Semantic.name());
+        String newCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(newVul);
+        AdvisoryWrapper newAdvisory = AdvisoryWrapper.updateFromExisting(oldAdvisory, csafToRequest(newCsafJson));
+
+        assertThat(AdvisoryWorkflowUtil.getChangeType(oldAdvisory, newAdvisory, 4), is(PatchType.MAJOR));
+    }
+
+    @Test
+    public void getChangeTypeTest_removeVulnerabilityProductStatusKnownAffected() throws IOException, CsafException {
+
+        String oldVul = """
+                 [ { "product_status": {
+                      "known_affected": ["CSAFPID-0001", "CSAFPID-0002"]
+                     }
+                   }
+                  ]
+                """;
+
+        String newVul = """
+                 [ { "product_status": {
+                      "known_affected": ["CSAFPID-0001"]
+                     }
+                   }
+                  ]
+                """;
+
+
+        String oldCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(oldVul);
+        AdvisoryWrapper oldAdvisory = AdvisoryWrapper.createNewFromCsaf(csafToRequest(oldCsafJson), "user1", Semantic.name());
+        String newCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(newVul);
+        AdvisoryWrapper newAdvisory = AdvisoryWrapper.updateFromExisting(oldAdvisory, csafToRequest(newCsafJson));
+
+        assertThat(AdvisoryWorkflowUtil.getChangeType(oldAdvisory, newAdvisory, 4), is(PatchType.MAJOR));
+    }
+
+    @Test
+    public void getChangeTypeTest_removeVulnerabilityProductStatusLastAffected() throws IOException, CsafException {
+
+        String oldVul = """
+                 [ { "product_status": {
+                      "last_affected": ["CSAFPID-0001", "CSAFPID-0002"]
+                     }
+                   }
+                  ]
+                """;
+
+        String newVul = """
+                 [ { "product_status": {
+                      "last_affected": ["CSAFPID-0001"]
+                     }
+                   }
+                  ]
+                """;
+
+
+        String oldCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(oldVul);
+        AdvisoryWrapper oldAdvisory = AdvisoryWrapper.createNewFromCsaf(csafToRequest(oldCsafJson), "user1", Semantic.name());
+        String newCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(newVul);
+        AdvisoryWrapper newAdvisory = AdvisoryWrapper.updateFromExisting(oldAdvisory, csafToRequest(newCsafJson));
+
+        assertThat(AdvisoryWorkflowUtil.getChangeType(oldAdvisory, newAdvisory, 4), is(PatchType.MAJOR));
+    }
+
+    @Test
+    public void getChangeTypeTest_removeVulnerabilityProductStatusFirstFixed() throws IOException, CsafException {
+
+        String oldVul = """
+                 [ { "product_status": {
+                      "first_fixed": ["CSAFPID-0001", "CSAFPID-0002"]
+                     }
+                   }
+                  ]
+                """;
+
+        String newVul =  """
+                 [ { "product_status": {
+                      "first_fixed": ["CSAFPID-0001"]
+                     }
+                   }
+                  ]
+                """;
+
+
+        String oldCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(oldVul);
+        AdvisoryWrapper oldAdvisory = AdvisoryWrapper.createNewFromCsaf(csafToRequest(oldCsafJson), "user1", Semantic.name());
+        String newCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(newVul);
+        AdvisoryWrapper newAdvisory = AdvisoryWrapper.updateFromExisting(oldAdvisory, csafToRequest(newCsafJson));
+
+        assertThat(AdvisoryWorkflowUtil.getChangeType(oldAdvisory, newAdvisory, 4), is(PatchType.MAJOR));
+    }
+
+    @Test
+    public void getChangeTypeTest_removeVulnerabilityProductStatusFixed() throws IOException, CsafException {
+
+        String oldVul = """
+                 [ { "product_status": {
+                      "fixed": ["CSAFPID-0001", "CSAFPID-0002"]
+                     }
+                   }
+                  ]
+                """;
+
+        String newVul = """
+                 [ { "product_status": {
+                      "fixed": ["CSAFPID-0001"]
+                     }
+                   }
+                  ]
+                """;
+
+
+        String oldCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(oldVul);
+        AdvisoryWrapper oldAdvisory = AdvisoryWrapper.createNewFromCsaf(csafToRequest(oldCsafJson), "user1", Semantic.name());
+        String newCsafJson = CsafDocumentJsonCreator.docWithVulnerabilities(newVul);
+        AdvisoryWrapper newAdvisory = AdvisoryWrapper.updateFromExisting(oldAdvisory, csafToRequest(newCsafJson));
+
+        assertThat(AdvisoryWorkflowUtil.getChangeType(oldAdvisory, newAdvisory, 4), is(PatchType.MAJOR));
+    }
+
+    @Test
+    public void getChangeTypeTest_removeVulnerabilityProductStatusKnownNotAffected() throws IOException, CsafException {
+
+        String oldVul = """
+                 [ { "product_status": {
+                      "known_not_affected": ["CSAFPID-0001", "CSAFPID-0002"]
+                     }
+                   }
+                  ]
+                """;
+
+        String newVul = """
+                 [ { "product_status": {
+                      "known_not_affected": ["CSAFPID-0001"]
                      }
                    }
                   ]


### PR DESCRIPTION
- checks validity of document before workflow state change to `RfPublication`
- add missing conditions on triggering major version raise
- adds more extensive tests on revision history changes
- sets revision history summaries dynamically instead of configured strings
- except in case of workflow state change to `Published` and raise an error when the required env variable `CSAF_SUMMARY_PUBLICATION` is empty
- includes some smaller fixes