### PR TITLE
fix(AdvisoryWrapper.java): check for empty string in currentReleaseDa…

### DIFF
--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/json/AdvisoryWrapper.java
@@ -643,6 +643,7 @@ public class AdvisoryWrapper {
      */
     public boolean currentReleaseDateIsNotSetOrInPast(String comparedTo) {
         return (this.getDocumentTrackingCurrentReleaseDate() == null
+                || this.getDocumentTrackingCurrentReleaseDate().isEmpty()
                 || timestampIsBefore(this.getDocumentTrackingCurrentReleaseDate(), comparedTo));
     }
 


### PR DESCRIPTION
…teIsNotSetOrInPast

empty string in `document.tracking.current_release_date` crashed the applicaiton