### PR TITLE
Remove HTTP If-Modified-Since Header 

### DIFF
--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClient.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClient.java
@@ -113,7 +113,6 @@ public class ValidatorServiceClient {
                     .accept(MediaType.APPLICATION_JSON)
                     .acceptCharset(StandardCharsets.UTF_8)
                     .ifNoneMatch("*")
-                    .ifModifiedSince(ZonedDateTime.now())
                     .retrieve()
                     .bodyToMono(String.class)
                     .block();

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClientTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClientTest.java
@@ -109,7 +109,6 @@ public class ValidatorServiceClientTest {
             when(requestHeadersSpec.accept(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.acceptCharset(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.ifNoneMatch(any())).thenReturn(requestHeadersSpec);
-            when(requestHeadersSpec.ifModifiedSince(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
             when(responseSpec.bodyToMono(ArgumentMatchers.<Class<String>>notNull())).thenReturn(Mono.just(jsonStr));
 
@@ -138,7 +137,6 @@ public class ValidatorServiceClientTest {
             when(requestHeadersSpec.accept(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.acceptCharset(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.ifNoneMatch(any())).thenReturn(requestHeadersSpec);
-            when(requestHeadersSpec.ifModifiedSince(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
             when(responseSpec.bodyToMono(ArgumentMatchers.<Class<String>>notNull())).thenReturn(Mono.just(jsonStr));
 
@@ -170,7 +168,6 @@ public class ValidatorServiceClientTest {
             when(requestHeadersSpec.accept(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.acceptCharset(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.ifNoneMatch(any())).thenReturn(requestHeadersSpec);
-            when(requestHeadersSpec.ifModifiedSince(any())).thenReturn(requestHeadersSpec);
             when(requestHeadersSpec.retrieve()).thenThrow(Mockito.mock(WebClientRequestException.class));
 
             final AdvisoryWrapper newAdvisoryNode = AdvisoryWrapper.createNewFromCsaf(


### PR DESCRIPTION
Removed check of HTTP If-Modified-Since Header as it is not needed and a reason for errors during tests.