### PR TITLE
Reduce test output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ test {
 	filter {
 		excludeTestsMatching "de.bsi.secvisogram.csaf_cms_backend.OpenApiGenerateDocuTest"
 	}
-	testLogging.showStandardStreams = true
+	testLogging.showStandardStreams = false
 }
 
 task apiDocumentation(type: Test, description: "generates the API documentation") {

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClient.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/validator/ValidatorServiceClient.java
@@ -120,11 +120,11 @@ public class ValidatorServiceClient {
             final ObjectMapper jacksonMapper = new ObjectMapper();
             return jacksonMapper.readValue(resultText, ValidatorResponse.class);
         } catch (WebClientResponseException | WebClientRequestException ex) {
-            LOG.error("Error in access to validation server", ex);
+            LOG.error("Error in access to validation server");
             throw new CsafException("Error in call to validation server",
                     CsafExceptionKey.ErrorAccessingValidationServer, HttpStatus.SERVICE_UNAVAILABLE);
         } catch (JsonProcessingException ex) {
-            LOG.error("Error creating request to validation server", ex);
+            LOG.error("Error parsing response from validation server: " + ex.getMessage());
             throw new CsafException("Error creating request to validation server",
                     CsafExceptionKey.ErrorAccessingValidationServer, HttpStatus.UNPROCESSABLE_ENTITY);
         }


### PR DESCRIPTION
During tests there are a lot of output on stdout and stderror from the application. Because of this, it is sometimes difficult to identify failed tests. Therefore the output is deactivated. Only failed tests will be written out.