### PR TITLE
Switch off output for tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ test {
 	filter {
 		excludeTestsMatching "de.bsi.secvisogram.csaf_cms_backend.OpenApiGenerateDocuTest"
 	}
-	testLogging.showStandardStreams = true
+	testLogging.showStandardStreams = false
 }
 
 task apiDocumentation(type: Test, description: "generates the API documentation") {


### PR DESCRIPTION
During tests there are a lot of output on stdout and stderror from the application. Because of this, it is sometimes difficult to identify failed tests. Therefore the output is deactivated. Only failed tests will be written out.