### PR TITLE
add test and build artifact folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ out/
 .env
 /bin/
 /target/
+docker/data/
+sbom/


### PR DESCRIPTION
The docker/data folder is the default folder to persist couchdb and postgreSQL databases for development. Its configured in the default compose.yaml.

In the sbom/ folder sboms generated during build are placed. Since they are build artifacts they should be ignored.

fixes #210 