### PR TITLE
Fix domain error msg supression

### DIFF
--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/rest/AdvisoryController.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/rest/AdvisoryController.java
@@ -16,6 +16,7 @@ import de.bsi.secvisogram.csaf_cms_backend.rest.response.AdvisoryInformationResp
 import de.bsi.secvisogram.csaf_cms_backend.rest.response.AdvisoryResponse;
 import de.bsi.secvisogram.csaf_cms_backend.rest.response.AdvisoryTemplateInfoResponse;
 import de.bsi.secvisogram.csaf_cms_backend.rest.response.AnswerInformationResponse;
+import de.bsi.secvisogram.csaf_cms_backend.rest.error.ApiError;
 import de.bsi.secvisogram.csaf_cms_backend.rest.response.CommentInformationResponse;
 import de.bsi.secvisogram.csaf_cms_backend.rest.response.EntityCreateResponse;
 import de.bsi.secvisogram.csaf_cms_backend.rest.response.EntityUpdateResponse;
@@ -158,7 +159,7 @@ public class AdvisoryController {
             LOG.info("Error reading Advisory");
             return ResponseEntity.internalServerError().build();
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         }
     }
 
@@ -224,9 +225,9 @@ public class AdvisoryController {
             LOG.info("Error reading Advisory");
             return ResponseEntity.internalServerError().build();
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         } catch (AccessDeniedException ex) {
-          return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+          return apiError(HttpStatus.UNAUTHORIZED, ex.getMessage());
         }
     }
 
@@ -280,9 +281,9 @@ public class AdvisoryController {
         } catch (JacksonException | IOException jpEx) {
             return ResponseEntity.badRequest().build();
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         }
     }
 
@@ -333,9 +334,9 @@ public class AdvisoryController {
         } catch (IOException jpEx) {
             return ResponseEntity.badRequest().build();
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         }
     }
 
@@ -409,9 +410,9 @@ public class AdvisoryController {
         } catch (DatabaseException dbEx) {
             return ResponseEntity.notFound().build();
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         }
 
     }
@@ -476,9 +477,9 @@ public class AdvisoryController {
         } catch (DatabaseException ex) {
             return ResponseEntity.notFound().build();
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         }
     }
 
@@ -544,10 +545,10 @@ public class AdvisoryController {
         } catch (IOException ioEx) {
             return ResponseEntity.internalServerError().build();
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         } catch (AccessDeniedException adEx) {
-          return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        } 
+          return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
+        }
     }
 
     /**
@@ -631,7 +632,8 @@ public class AdvisoryController {
         LOG.debug("readTemplate");
         try {
             Optional<JsonNode> templateJson = this.templateService.getTemplate(templateId);
-            return templateJson.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+            return templateJson.map(ResponseEntity::ok)
+                    .orElseGet(() -> apiError(HttpStatus.NOT_FOUND, "Template not found"));
         } catch (IOException ex) {
             LOG.error(String.format("Error loading template with id: %s", sanitize(templateId)), ex);
             return ResponseEntity.internalServerError().build();
@@ -712,7 +714,7 @@ public class AdvisoryController {
             LOG.error("Error happened when creating the export: ", e);
             return ResponseEntity.internalServerError().build();
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         } finally {
             if (filePath != null) {
                 LOG.info(String.format("Deleting file: %s", filePath));
@@ -1117,9 +1119,9 @@ public class AdvisoryController {
         try {
             return ResponseEntity.ok(advisoryService.getComments(advisoryId));
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         }
     }
 
@@ -1185,14 +1187,14 @@ public class AdvisoryController {
             EntityCreateResponse createResponse = new EntityCreateResponse(idRev.getId(), idRev.getRevision());
             return ResponseEntity.created(commentLocation).body(createResponse);
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         } catch (IllegalArgumentException ex) {
             return ResponseEntity.badRequest().build();
         } catch (DatabaseException dbEx) {
             LOG.error("Error creating comment");
             return ResponseEntity.internalServerError().build();
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         }
     }
 
@@ -1252,9 +1254,9 @@ public class AdvisoryController {
         try {
             return ResponseEntity.ok(advisoryService.getAnswers(advisoryId, commentId));
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         }
     }
 
@@ -1320,9 +1322,9 @@ public class AdvisoryController {
             LOG.error("Error creating answer");
             return ResponseEntity.internalServerError().build();
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         }
     }
 
@@ -1400,9 +1402,9 @@ public class AdvisoryController {
         } catch (IOException ioEx) {
             return ResponseEntity.internalServerError().build();
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         }
     }
 
@@ -1477,10 +1479,18 @@ public class AdvisoryController {
         } catch (IOException ioEx) {
             return ResponseEntity.internalServerError().build();
         } catch (AccessDeniedException adEx) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return apiError(HttpStatus.UNAUTHORIZED, adEx.getMessage());
         } catch (CsafException ex) {
-            return ResponseEntity.status(ex.getRecommendedHttpState()).build();
+            return apiError(ex.getRecommendedHttpState(), ex.getMessage());
         }
+    }
+
+    /**
+     * Build an error response body.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> ResponseEntity<T> apiError(HttpStatus status, String message) {
+        return (ResponseEntity<T>) ResponseEntity.status(status).body(new ApiError(message));
     }
 
     /**

--- a/src/main/java/de/bsi/secvisogram/csaf_cms_backend/rest/error/ApiError.java
+++ b/src/main/java/de/bsi/secvisogram/csaf_cms_backend/rest/error/ApiError.java
@@ -1,0 +1,18 @@
+package de.bsi.secvisogram.csaf_cms_backend.rest.error;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "ApiError")
+public class ApiError {
+
+    private final String message;
+
+    public ApiError(String message) {
+        this.message = message;
+    }
+
+    @Schema(description = "A human-readable description of the error.", example = "Advisory is not in state final or interim")
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/test/java/de/bsi/secvisogram/csaf_cms_backend/rest/AdvisoryControllerTest.java
+++ b/src/test/java/de/bsi/secvisogram/csaf_cms_backend/rest/AdvisoryControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import tools.jackson.databind.JsonNode;
@@ -152,7 +153,8 @@ public class AdvisoryControllerTest {
                 .thenThrow(csafExcp);
 
         this.mockMvc.perform(get(advisoryRoute))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
     }
 
     @Test
@@ -207,7 +209,8 @@ public class AdvisoryControllerTest {
         when(advisoryService.getAdvisory(any())).thenThrow(csafExcp);
 
         this.mockMvc.perform(get(advisoryRoute + "/" + UUID.randomUUID()))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
 
     }
 
@@ -275,7 +278,8 @@ public class AdvisoryControllerTest {
 
         this.mockMvc.perform(
                         post(advisoryRoute).with(csrf()).content(csafJsonString).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
     }
 
     @Test
@@ -343,7 +347,8 @@ public class AdvisoryControllerTest {
                         .content(CsafDocumentJsonCreator.csafMinimalValidDoc(Draft, "0.0.1"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("revision", revision))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
     }
 
     @Test
@@ -436,7 +441,8 @@ public class AdvisoryControllerTest {
 
         this.mockMvc.perform(delete(advisoryRoute + "/" + advisoryId).with(csrf())
                         .param("revision", revision))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("wrong id"));
 
     }
 
@@ -603,7 +609,8 @@ public class AdvisoryControllerTest {
                         .param("revision", revision)
                         .param("proposedTime", "2022-07-15T05:50:21Z")
                         .param("documentTrackingStatus", "Interim"))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string("access denied"));
     }
 
     @Test
@@ -631,7 +638,8 @@ public class AdvisoryControllerTest {
                         .param("revision", revision)
                         .param("proposedTime", "2022-07-15T05:50:21Z")
                         .param("documentTrackingStatus", "Interim"))
-                .andExpect(status().isUnprocessableEntity());
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(content().string("Invalid Advisory"));
     }
 
     @Test
@@ -645,7 +653,8 @@ public class AdvisoryControllerTest {
                         .param("revision", revision)
                         .param("proposedTime", "2022-07-15T05:50:21Z")
                         .param("documentTrackingStatus", "Interim"))
-                .andExpect(status().isServiceUnavailable());
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().string("Validation Service not Available"));
     }
 
     @Test
@@ -670,7 +679,8 @@ public class AdvisoryControllerTest {
 
         this.mockMvc.perform(patch(advisoryRoute + "/" + advisoryId + "/createNewVersion").with(csrf())
                         .param("revision", revision))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("access denied"));
     }
 
     @Test
@@ -742,7 +752,8 @@ public class AdvisoryControllerTest {
                         get(advisoryRoute + "/" + advisoryId + "/csaf")
                                 .with(csrf()).content(csafJsonString).contentType(MediaType.TEXT_HTML)
                                 .param("format", ExportFormat.HTML.name()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("wrong id"));
     }
 
     @Test
@@ -850,7 +861,8 @@ public class AdvisoryControllerTest {
         when(advisoryService.getComments(advisoryId)).thenThrow(csafExcp);
 
         this.mockMvc.perform(get(commentRoute))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
     }
 
     @Test
@@ -950,7 +962,8 @@ public class AdvisoryControllerTest {
                 """;
         this.mockMvc.perform(
                         post(commentRoute).with(csrf()).content(commentJson).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
     }
 
     @Test
@@ -1076,7 +1089,8 @@ public class AdvisoryControllerTest {
                         .content(commentText)
                         .contentType(MediaType.TEXT_PLAIN)
                         .param("revision", revision))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("wrong id"));
     }
 
     @Test
@@ -1149,7 +1163,8 @@ public class AdvisoryControllerTest {
         when(advisoryService.getAnswers(advisoryId, commentId)).thenThrow(csafExcp);
 
         this.mockMvc.perform(get(answerRoute))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
     }
 
     @Test
@@ -1162,7 +1177,8 @@ public class AdvisoryControllerTest {
 
         this.mockMvc.perform(
                         post(answerRoute).content(invalidJson).contentType(MediaType.APPLICATION_JSON).with(csrf()))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Advisory not found"));
     }
 
     @Test
@@ -1285,7 +1301,8 @@ public class AdvisoryControllerTest {
                         .content(answerText)
                         .contentType(MediaType.TEXT_PLAIN)
                         .param("revision", revision))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("wrong id"));
     }
 
     @Test
@@ -1376,7 +1393,8 @@ public class AdvisoryControllerTest {
         this.mockMvc.perform(post(advisoryRoute + "/import").with(csrf())
                         .content(CsafDocumentJsonCreator.csafMinimalValidDoc(Draft, "0.0.1"))
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()));
+                .andExpect(status().is(csafExcp.getRecommendedHttpState().value()))
+                .andExpect(jsonPath("$.message").value(csafExcp.getMessage()));
     }
 
     @Test


### PR DESCRIPTION
Surface CsafException/AccessDeniedException messages to API clients

Domain error messages carried by CsafException and AccessDeniedException were being discarded in catch blocks of AdvisoryController. That lead to confusing messages being shown in the UI, like "Unauthorized" instead of "User has no permission to edit the advisory". For pure technical error messages the handling was left as it was, since they carry internal details that weren't written for API consumers. There is a corresponding change for Frontend (Secvisogram) as well (=> [#822](https://github.com/secvisogram/secvisogram/pull/822)).

Fixes #248
