### PR TITLE
ci: trigger Build and Test workflow on push to main

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We need a build of the main branch when changes are pushed to it. This is nomal continuous integration. 
Until now a build is done for a branch when a PR is opened. That build can be green, but if new changes get into main before the PR is merged, then there is no automatic re-build and main could have been broken.