### PR TITLE
chore(docker): bump keycloak image to 26.7.2 to patch CVE-2026-18963,…

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4
+    image: quay.io/keycloak/keycloak:26.7.2
     env_file: .env
     environment:
       # https://www.keycloak.org/server/all-config
@@ -157,12 +157,12 @@ services:
         condition: service_healthy
     
   validator:
-    image: ghcr.io/secvisogram/csaf-validator-service:sha-119ec6f
+    image: ghcr.io/secvisogram/csaf-validator-service:sha-8b4919b
     env_file: .env
     ports:
       - "$CSAF_VALIDATOR_PORT:8082"
     healthcheck:
-      test: ["CMD-SHELL", "wget -O /dev/null http://127.0.0.1:8082/api/v1/tests || exit 1"]
+      test: ["CMD-SHELL", "wget -O /dev/null http://127.0.0.1:8082/health || exit 1"]
       interval: 10s
       timeout: 10s
       retries: 10 
@@ -198,7 +198,7 @@ services:
     restart: on-failure
 
   secvisogram:
-    image: ghcr.io/secvisogram/secvisogram:sha-047abf8
+    image: ghcr.io/secvisogram/secvisogram:sha-7553171
     volumes:
       - "./config/secvisogram/appspecific:/usr/share/nginx/html/.well-known/appspecific:ro"
     healthcheck:


### PR DESCRIPTION
… use new validator healthcheck endpoint, bump validator and secvisogram image versions